### PR TITLE
TEL-4234 use smaller alpine image

### DIFF
--- a/.cruft.json
+++ b/.cruft.json
@@ -1,6 +1,6 @@
 {
   "template": "https://github.com/hmrc/telemetry-docker-resources",
-  "commit": "04a7fdeae17f888fa5ae9405d6c03c9cce16acd1",
+  "commit": "8ab9d184a09aa7e502d986e76275334f5d836612",
   "checkout": null,
   "context": {
     "cookiecutter": {

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -42,7 +42,7 @@ repos:
         name: Fix missing end-of-file line returns
         exclude: repository.yaml|tests/unit/test-data/
   - repo: https://github.com/hmrc/security-git-hooks
-    rev: release/1.9.0
+    rev: release/1.10.0
     hooks:
       - id: secrets_filecontent
         name: Checking staged files for sensitive content

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,22 +1,7 @@
 ARG DOCKER_DEFAULT_PLATFORM
-ARG GO_VERSION
-FROM --platform=$DOCKER_DEFAULT_PLATFORM golang:${GO_VERSION} as compile-image
+FROM --platform=$DOCKER_DEFAULT_PLATFORM dockerhub.tax.service.gov.uk/segment/topicctl as topicctl-image
 
-ARG TOPICCTL_VERSION
+FROM --platform=$DOCKER_DEFAULT_PLATFORM dockerhub.tax.service.gov.uk/alpine:latest AS build-image
+COPY --from=topicctl-image /bin/topicctl /bin/topicctl
 
-LABEL org.opencontainers.image.authors="telemetry@digital.hmrc.gov.uk"
-LABEL version.golang="${GO_VERSION}"
-LABEL version.topicctl="${TOPICCTL_VERSION}"
-
-COPY bin/install_build_tools.sh ./
-RUN ./install_build_tools.sh -t ${TOPICCTL_VERSION}
-
-FROM --platform=$DOCKER_DEFAULT_PLATFORM ubuntu:latest AS build-image
-COPY --from=compile-image /go/bin/topicctl /bin/topicctl
-
-COPY bin/install_packages.sh ./
-RUN ./install_packages.sh
-
-# Taken from GitHub source
-# https://github.com/segmentio/topicctl/blob/master/Dockerfile
 ENTRYPOINT ["/bin/topicctl"]

--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,7 @@ publish_to_ecr: ## Push the Docker image to the internal-base ECR repo
 .PHONY: publish_to_ecr
 
 setup: check_poetry ## Setup virtualenv & dependencies using poetry and set-up the git hook scripts
-	@export POETRY_VIRTUALENVS_IN_PROJECT=$(POETRY_VIRTUALENVS_IN_PROJECT) && poetry run pip install --upgrade pip
+	@export POETRY_VIRTUALENVS_IN_PROJECT=$(POETRY_VIRTUALENVS_IN_PROJECT) && poetry run pip install --index-url https://artefacts.tax.service.gov.uk/artifactory/api/pypi/pips/simple --upgrade pip
 	@poetry config --list
 	@poetry install --no-root
 	@poetry run pre-commit install

--- a/buildspec_pr.yml
+++ b/buildspec_pr.yml
@@ -11,5 +11,5 @@ phases:
       - make setup
   build:
     commands:
-      - pre-commit run --all-files --verbose
+      - PIP_INDEX_URL=https://artefacts.tax.service.gov.uk/artifactory/api/pypi/pips/simple pre-commit run --all-files --verbose
       - make verify


### PR DESCRIPTION
What did we do?
--

1. Updated image to use smaller alpine image
2. Simplified dockerfile so that it just gets the binary from the official topicctl image

References
--

https://jira.tools.tax.service.gov.uk/browse/TEL-4234

Evidence of work
--

1. Tested in lab02 - can execute a shell and run topicctl commands:
<img width="698" alt="image" src="https://github.com/hmrc/telemetry-docker-topicctl/assets/18111914/a1ebac33-b864-48a0-831d-7ad25e648a45">

