### PR TITLE
TEL-4234 rename repo to telemetry-docker-msk-tools

### DIFF
--- a/.cruft.json
+++ b/.cruft.json
@@ -7,11 +7,11 @@
       "aws_account_id": "634456480543",
       "aws_region": "eu-west-2",
       "custom_makefile_name": "",
-      "docker_build_options_default": "--platform 'linux/amd64' --build-arg BUILDKIT_INLINE_CACHE=1 --build-arg DOCKER_DEFAULT_PLATFORM='linux/amd64' --build-arg GO_VERSION=1.19.3 --build-arg TOPICCTL_VERSION=latest",
-      "docker_image_name": "telemetry-docker-topicctl",
-      "docker_image_name_formatted": "telemetry-docker-topicctl",
+      "docker_build_options_default": "--platform 'linux/amd64' --build-arg BUILDKIT_INLINE_CACHE=1 --build-arg DOCKER_DEFAULT_PLATFORM='linux/amd64'",
+      "docker_image_name": "telemetry-docker-msk-tools",
+      "docker_image_name_formatted": "telemetry-docker-msk-tools",
       "docker_include_default_build": true,
-      "repository_name": "telemetry-docker-topicctl",
+      "repository_name": "telemetry-docker-msk-tools",
       "additional_tool_versions": {
         "golang": "1.19.3"
       },

--- a/README.md
+++ b/README.md
@@ -1,14 +1,15 @@
-# telemetry-docker-topicctl
+# telemetry-docker-msk-tools
 
 [![Brought to you by Telemetry Team](https://img.shields.io/badge/MDTP-Telemetry-40D9C0?style=flat&labelColor=000000&logo=gov.uk)](https://confluence.tools.tax.service.gov.uk/display/TEL/Telemetry)
 
-This repository is responsible for building the topicctl Go binary into a Docker image that is compatible with running
+This repository is responsible for building the topicctl & kaf golang binaries into a Docker image that is compatible with running
 `AWS ECS exec` in Fargate
 
 
 ## References
 
 * [topicctl GitHub Repo](https://github.com/segmentio/topicctl)
+* [kaf GitHub Repo](https://github.com/birdayz/kaf)
 * [Running AWS ECS Exec](https://aws.amazon.com/blogs/containers/new-using-amazon-ecs-exec-access-your-containers-fargate-ec2/)
 * [ECS Exec in JetBrains AWS Toolkit](https://docs.aws.amazon.com/toolkit-for-jetbrains/latest/userguide/ecs-exec.html)
 

--- a/bin/docker-tools.sh
+++ b/bin/docker-tools.sh
@@ -12,7 +12,7 @@ set -o nounset
 ## Beginning of the configurations ##################################
 
 BASE_LOCATION="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-IMAGE_NAME="telemetry-docker-topicctl"
+IMAGE_NAME="telemetry-docker-msk-tools"
 
 ## End of the configurations ########################################
 #####################################################################
@@ -40,7 +40,7 @@ package() {
   poetry export --without-hashes --format requirements.txt --with dev --output "requirements-tests.txt"
 
   echo Building the images
-  docker build --tag "634456480543.dkr.ecr.eu-west-2.amazonaws.com/telemetry-docker-topicctl:${VERSION}" --platform 'linux/amd64' --build-arg BUILDKIT_INLINE_CACHE=1 --build-arg DOCKER_DEFAULT_PLATFORM='linux/amd64' --build-arg GO_VERSION=1.19.3 --build-arg TOPICCTL_VERSION=latest .
+  docker build --tag "634456480543.dkr.ecr.eu-west-2.amazonaws.com/telemetry-docker-msk-tools:${VERSION}" --platform 'linux/amd64' --build-arg BUILDKIT_INLINE_CACHE=1 --build-arg DOCKER_DEFAULT_PLATFORM='linux/amd64' .
   print_completed
 }
 
@@ -60,7 +60,7 @@ publish_to_ecr() {
   aws ecr get-login-password --region "eu-west-2" | docker login --username AWS --password-stdin "634456480543.dkr.ecr.eu-west-2.amazonaws.com"
 
   echo Pushing the images
-  docker push "634456480543.dkr.ecr.eu-west-2.amazonaws.com/telemetry-docker-topicctl:${VERSION}"
+  docker push "634456480543.dkr.ecr.eu-west-2.amazonaws.com/telemetry-docker-msk-tools:${VERSION}"
   print_completed
 }
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,11 +1,11 @@
 [tool.poetry]
-name = "telemetry-docker-topicctl"
+name = "telemetry-docker-msk-tools"
 version = "0.1.0"
-description = "Responsible for building the topicctl Go binary into a Docker image"
+description = "Responsible for adding the topicctl & kaf golang binaries into a Docker image"
 authors = ["Team Telemetry <telemetry@digital.hmrc.gov.uk>"]
 license = "Apache 2.0"
 readme = "README.md"
-packages = [{include = "telemetry_docker_topicctl"}]
+packages = [{include = "telemetry_docker_msk_tools"}]
 
 [[tool.poetry.source]]
 name = "artifactory"


### PR DESCRIPTION
What did we do?
--

1. Update all references to the old repo name (renamed from topicctl to msk-tools)

References
--

https://jira.tools.tax.service.gov.uk/browse/TEL-4234
https://jira.tools.tax.service.gov.uk/browse/TSR-31367

Collaboration
--

Co-authored-by: Jonny Heywood <60072280+jonnydh@users.noreply.github.com>
