### PR TITLE
TEL-5271 test if Codebuild knows we are on main branch

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -11,4 +11,6 @@ phases:
       - make setup
   build:
     commands:
+      - echo "$CODEBUILD_WEBHOOK_BASE_REF"
+      - echo "$CODEBUILD_WEBHOOK_HEAD_REF"
       - make verify_publish_release

--- a/buildspec_pr.yml
+++ b/buildspec_pr.yml
@@ -11,5 +11,7 @@ phases:
       - make setup
   build:
     commands:
+      - echo "$CODEBUILD_WEBHOOK_BASE_REF"
+      - echo "$CODEBUILD_WEBHOOK_HEAD_REF"
       - PIP_INDEX_URL=https://artefacts.tax.service.gov.uk/artifactory/api/pypi/pips/simple poetry run pre-commit run --all-files --verbose
       - make verify


### PR DESCRIPTION
What did we do?
--

1. Echo codebuild env vars to see if it knows that it has been trigger by the `main` branch

Evidence of work
--

On a PR we get this:
<img width="607" alt="image" src="https://github.com/user-attachments/assets/b794c0f3-faa9-45dc-b573-7ff0d3e88969" />
